### PR TITLE
Make sure mapGraphicsPosition returns Position3D

### DIFF
--- a/addons/CLib/MapGraphics/fn_mapGraphicsPosition.sqf
+++ b/addons/CLib/MapGraphics/fn_mapGraphicsPosition.sqf
@@ -8,7 +8,7 @@
     Converts a Position from MapGraphicsPosition into a position
 
     Parameter(s):
-    0: Position <MapGraphicsPosition> (Default: objNull)
+    0: Position <Array, Object> (MapGraphicsPosition) (Default: objNull)
     1: Map <Control> (Default: controlNull)
 
     Returns:

--- a/addons/CLib/MapGraphics/fn_mapGraphicsPosition.sqf
+++ b/addons/CLib/MapGraphics/fn_mapGraphicsPosition.sqf
@@ -34,7 +34,7 @@ if (_position isEqualType []) then {
         _pos = [(_pos select 0) + (_offset select 0) / 640, (_pos select 1) + (_offset select 1) / 480];
         _pos = _map ctrlMapScreenToWorld _pos;
         _position = _pos;
-    }
+    };
 
     // Make sure the returned position is Position3D
     private _originalLength = count _position;

--- a/addons/CLib/MapGraphics/fn_mapGraphicsPosition.sqf
+++ b/addons/CLib/MapGraphics/fn_mapGraphicsPosition.sqf
@@ -2,17 +2,17 @@
 /*
     Community Lib - CLib
 
-    Author: BadGuy
+    Author: BadGuy, Raven
 
     Description:
     Converts a Position from MapGraphicsPosition into a position
 
     Parameter(s):
-    0: Position <Array, Object> (Default: objNull)
+    0: Position <MapGraphicsPosition> (Default: objNull)
     1: Map <Control> (Default: controlNull)
 
     Returns:
-    Position <Array>
+    Position <Position3D>
 
     TYPE <MapGraphicsPosition>:
     OBJECT | POSITION3D | POSITION2D | [OBJECT | POSITION3D | POSITION2D,[ScreenOffsetX,ScreenOffsetY]]
@@ -23,16 +23,28 @@ params [
     ["_map", controlNull, [controlNull]]
 ];
 
-if (_position isEqualType [] && {(_position select 1) isEqualType []}) then {
-    _position params ["_pos", "_offset"];
+if (_position isEqualType []) then {
+    if ((_position select 1) isEqualType []) then {
+        _position params ["_pos", "_offset"];
 
-    if (_pos isEqualType objNull) then {
-        _pos = getPosVisual _pos;
+        if (_pos isEqualType objNull) then {
+            _pos = getPosVisual _pos;
+        };
+        _pos = _map ctrlMapWorldToScreen _pos;
+        _pos = [(_pos select 0) + (_offset select 0) / 640, (_pos select 1) + (_offset select 1) / 480];
+        _pos = _map ctrlMapScreenToWorld _pos;
+        _position = _pos;
+    }
+
+    // Make sure the returned position is Position3D
+    private _originalLength = count _position;
+    _position resize 3;
+    
+    // If the original position did contain fewer than 3 entries, replace the nil values inserted by the resize commands
+    // with zeros
+    for "_i" from _originalLength to 3 do {
+        _position set [_i, 0];
     };
-    _pos = _map ctrlMapWorldToScreen _pos;
-    _pos = [(_pos select 0) + (_offset select 0) / 640, (_pos select 1) + (_offset select 1) / 480];
-    _pos = _map ctrlMapScreenToWorld _pos;
-    _position = _pos;
 };
 
 if (_position isEqualType objNull) then {

--- a/addons/CLib/MapGraphics/fn_mapGraphicsPosition.sqf
+++ b/addons/CLib/MapGraphics/fn_mapGraphicsPosition.sqf
@@ -12,7 +12,7 @@
     1: Map <Control> (Default: controlNull)
 
     Returns:
-    Position <Position3D>
+    Position <Array> (Position3D)
 
     TYPE <MapGraphicsPosition>:
     OBJECT | POSITION3D | POSITION2D | [OBJECT | POSITION3D | POSITION2D,[ScreenOffsetX,ScreenOffsetY]]
@@ -37,13 +37,14 @@ if (_position isEqualType []) then {
     };
 
     // Make sure the returned position is Position3D
-    private _originalLength = count _position;
-    _position resize 3;
-    
-    // If the original position did contain fewer than 3 entries, replace the nil values inserted by the resize commands
-    // with zeros
-    for "_i" from _originalLength to 3 do {
-        _position set [_i, 0];
+    private _size = count _position;
+    if (_size != 3) then {
+        if (_size > 3) then {
+            _position resize 3;
+        } else {
+            // Array size is 2 as the only other valid option at this point is Position2D
+            _position pushBack 0;
+        };
     };
 };
 

--- a/addons/CLib/MapGraphics/fn_mapGraphicsPosition.sqf
+++ b/addons/CLib/MapGraphics/fn_mapGraphicsPosition.sqf
@@ -8,11 +8,11 @@
     Converts a Position from MapGraphicsPosition into a position
 
     Parameter(s):
-    0: Position <Array, Object> (MapGraphicsPosition) (Default: objNull)
+    0: MapGraphicsPosition <Array, Object> (Default: objNull)
     1: Map <Control> (Default: controlNull)
 
     Returns:
-    Position <Array> (Position3D)
+    Position3D <Array>
 
     TYPE <MapGraphicsPosition>:
     OBJECT | POSITION3D | POSITION2D | [OBJECT | POSITION3D | POSITION2D,[ScreenOffsetX,ScreenOffsetY]]


### PR DESCRIPTION
As e.g. drawPolygon does not accept 2D positions, this function must indeed return a 3D position.

Missing coordinates are filled in as zero.

----

Note: This is untested