### PR TITLE
Convert _mousePosition to Position3D

### DIFF
--- a/addons/CLib/MapGraphics/fn_nearestMapGraphicsGroup.sqf
+++ b/addons/CLib/MapGraphics/fn_nearestMapGraphicsGroup.sqf
@@ -24,6 +24,8 @@ params [
 
 private _mousePosition = [_xPos, _yPos];
 _mousePosition = _map ctrlMapScreenToWorld _mousePosition;
+// ctrlMapScreenToWorld yields Position2D, but we want a Position3D (e.g. inPolygon requires it)
+_mousePosition pushBack 0;
 
 private _r = 100000;
 private _nearestIcon = "";


### PR DESCRIPTION
For instance inPolygon requires the mouse position to be in format Position3D

----

Note: This is untested