### PR TITLE
Fix variable name typo

### DIFF
--- a/addons/CLib/PerFrame/fn_init.sqf
+++ b/addons/CLib/PerFrame/fn_init.sqf
@@ -21,7 +21,7 @@ GVAR(waitUntilArray) = [];
 
 GVAR(perFrameHandlerArray) = [];
 GVAR(PFHhandles) = [];
-GVAR(deletedIndexes) = [];
+GVAR(deletedIndices) = [];
 
 GVAR(skipFrameArray) = [];
 GVAR(sortSkipFrameArray) = false;


### PR DESCRIPTION
The variable was initialized as `deletedIndexes` in PerFrame/fn_init.sqf but was referenced
as `deletedIndices` in PerFrame/fn_removePerFrameHandler.sqf.

Thus the variable that was referenced in the remove function was nil, causing that part of the code to abort at the 
first time that variable is referenced.
This prevents old PFHs to actually get removed, causing these old handlers to accumulate.

----

This is where that variable currently gets used (this is the only usage I was able to find using GitHub's search):
https://github.com/TaktiCool/CLib/blob/ee1f6a02cb3b0bd31265e8ae68c8658d9af808e0/addons/CLib/PerFrame/fn_removePerframeHandler.sqf#L32-L48

Credit to @formtapez for discovering the accumulation of PFHs using the following code:
```sqf
systemChat format["Before: CBA-PFHs: %1 // CLib-PFHs: %2", count cba_common_perFrameHandlerArray, count CLib_Perframe_perFrameHandlerArray]; 
 
_cba_pfh = [{systemChat "This CBA PFH will be deleted before execution.";}, 1] call CBA_fnc_addPerFrameHandler; 
_cba_pfh call CBA_fnc_removePerFrameHandler; 
 
_clib_pfh = [{systemChat "This CLib PFH will be deleted before execution.";}, 1] call CLib_fnc_addPerFrameHandler; 
_clib_pfh call CLib_fnc_removePerframeHandler;  

[] spawn {sleep 0.2; systemChat format["After: CBA-PFHs: %1 // CLib-PFHs: %2", count cba_common_perFrameHandlerArray, count CLib_Perframe_perFrameHandlerArray];};
```
(to be executed multiple times from the in-game debug console)
This demonstrates that in CBA the PFH gets removed as expected whereas in CLib this is not the case.